### PR TITLE
fix: disable Spring Security and JPA auto-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # HabitHacker
 
-Backend API for a smart habit tracker. Project in active development.
+Backend API for a smart habit tracker. Project in active development.[mvnw](mvnw)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=Habithacker
+
+# ????????? Security ? JPA/DataSource ????????????????
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,\
+  org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
+  org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
+  org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
+
+server.port=8080


### PR DESCRIPTION
## Что было сделано?
Отключена автоконфигурация Spring Security и Spring Data JPA в файле `application.properties`.

## Почему это было необходимо?
Приложение не запускалось из-за ошибок:
1. Spring Security требовал аутентификацию на всех endpoint'ах
2. Spring Data JPA не мог найти DataSource для подключения к БД

## Результат
Приложение теперь успешно запускается и готова к разработке базовых контроллеров.

Closes #2